### PR TITLE
Preparations for non-intrusive TypeScript type-checking and first suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/UserStalkerHelper.user.js
+++ b/UserStalkerHelper.user.js
@@ -160,40 +160,28 @@
    }
 
 
-   function getChatFkey()
+   async function getChatFkey()
    {
-      return new Promise(function(resolve, reject)
-      {
-         if (fkey?.fkey)
-         {
-            resolve(fkey.fkey());
-         }
-         else
-         {
-            // The "search" page does not define the user's chat FKEY anywhere,
-            // so we need to fetch it from a page that does.
-            GM_XML_HTTP_REQUEST(
-            {
-               method : 'GET',
-               url    : `//${HOSTNAME_CHAT}`,
-               onload : (result) =>
-                        {
-                           const fkeyInput = $(result.response).find('input#fkey');
-                           if (fkeyInput && fkeyInput.length)
-                           {
-                              resolve(fkeyInput.val());
-                           }
-                           else
-                           {
-                              alert('Failed to get your chat account\'s FKEY.');
-                              reject();
-                           }
-                        },
-               onerror: reject,
-               onabort: reject,
-            });
-         }
-      });
+        if (fkey?.fkey)
+        {
+            return fkey.fkey();
+        }
+
+        // The "search" page does not define the user's chat FKEY anywhere,
+        // so we need to fetch it from a page that does.
+        const result = await GM_XML_HTTP_REQUEST(
+        {
+           method : 'GET',
+           url    : `//${HOSTNAME_CHAT}`
+        });
+
+        const fkeyInput = $(result.response).find('input#fkey');
+        if (fkeyInput.length) {
+             return fkeyInput.val();
+        }
+
+        alert('Failed to get your chat account\'s FKEY.');
+        throw new Error("chat fkey getter failed");
    }
 
    function getChatMessage(fkeyChat, messageId)

--- a/UserStalkerHelper.user.js
+++ b/UserStalkerHelper.user.js
@@ -184,22 +184,25 @@
         throw new Error("chat fkey getter failed");
    }
 
-   function getChatMessage(fkeyChat, messageId)
-   {
-      return new Promise(function(resolve, reject)
-      {
-            $.get(`//${HOSTNAME_CHAT}/message/${messageId}`,
-                  {
-                     fkey : fkeyChat,
-                     plain: true,
-                  })
-                  .done((result) =>
-                  {
-                     resolve(result);
-                  })
-                  .fail(reject);
-      });
-   }
+    /**
+     * @param {string} fkeyChat chat fkey
+     * @param {number} messageId id of the chat message
+     */
+    async function getChatMessage(fkeyChat, messageId)
+    {
+        const params = new URLSearchParams({
+            fkey: fkeyChat,
+            plain: "true"
+        });
+
+        const url = new URL(`//${HOSTNAME_CHAT}/message/${messageId}`);
+        url.search = params.toString();
+
+        return GM_XML_HTTP_REQUEST({
+            method : "GET",
+            url    : url.toString()
+        });
+    }
 
    function editChatMessage(fkeyChat, messageId, messageText)
    {

--- a/UserStalkerHelper.user.js
+++ b/UserStalkerHelper.user.js
@@ -255,26 +255,25 @@
       });
    }
 
-
-   function getMainSiteFkey(siteHostname)
+   /**
+    * @param {string} siteHostname name of the network site host
+    */
+   async function getMainSiteFkey(siteHostname)
    {
-      return new Promise(function(resolve, reject)
-      {
-         if (siteHostname == null)
-         {
-            reject();
-         }
 
-         GM_XML_HTTP_REQUEST(
-         {
+        if (siteHostname == null)
+        {
+           throw new Error("missing hostname");
+        }
+        
+        const result = await GM_XML_HTTP_REQUEST(
+        {
             method : 'GET',
-            url    : `//${siteHostname}/users/${CHAT.CURRENT_USER_ID}`,
-            onload : (result) => { resolve($(result.response).find('input[name="fkey"]')[0].value); },
-            onerror: reject,
-            onabort: reject,
-         });
-      });
-   }
+            url    : `//${siteHostname}/users/${CHAT.CURRENT_USER_ID}`
+        });
+
+        return $(result.response).find('input[name="fkey"]')[0].value;
+    }
 
 
    function getUserInfofromApi(siteHostname, userId)

--- a/UserStalkerHelper.user.js
+++ b/UserStalkerHelper.user.js
@@ -29,7 +29,7 @@
    // Client ID is 21280 (https://stackapps.com/apps/oauth/view/21280)
    const SE_API_KEY          = 'F9msnTSnUmKMKD7BnjHAxA((';
    const GM_XML_HTTP_REQUEST = ((typeof GM !== 'undefined') ? GM.xmlHttpRequest.bind(GM)
-                                                            : GM_xmlHttpRequest);  /* eslint-disable-line no-undef */
+                                                            : GM_xmlhttpRequest);  /* eslint-disable-line no-undef */
    const HOSTNAME_CHAT       = window.location.hostname;
    const IS_TRANSCRIPT       = window.location.pathname.startsWith('/transcript');
    const IS_SEARCH           = window.location.pathname.startsWith('/search');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,170 @@
+{
+  "name": "UserStalkerHelper",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/greasemonkey": "^4.0.2",
+        "@types/tampermonkey": "^4.0.5",
+        "@userscripters/stackexchange-global-types": "^2.2.1"
+      }
+    },
+    "node_modules/@stimulus/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==",
+      "dev": true,
+      "dependencies": {
+        "@stimulus/mutation-observers": "^2.0.0"
+      }
+    },
+    "node_modules/@stimulus/multimap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-2.0.0.tgz",
+      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==",
+      "dev": true
+    },
+    "node_modules/@stimulus/mutation-observers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz",
+      "integrity": "sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==",
+      "dev": true,
+      "dependencies": {
+        "@stimulus/multimap": "^2.0.0"
+      }
+    },
+    "node_modules/@stimulus/webpack-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz",
+      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==",
+      "dev": true
+    },
+    "node_modules/@types/greasemonkey": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
+      "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.8.tgz",
+      "integrity": "sha512-cXk6NwqjDYg+UI9p2l3x0YmPa4m7RrXqmbK4IpVVpRJiYXU/QTo+UZrn54qfE1+9Gao4qpYqUnxm5ZCy2FTXAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "node_modules/@types/tampermonkey": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
+      "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
+      "dev": true
+    },
+    "node_modules/@userscripters/stackexchange-global-types": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@userscripters/stackexchange-global-types/-/stackexchange-global-types-2.2.1.tgz",
+      "integrity": "sha512-+WTeOcVbIfHFvx+GA3nxYnlhe7MY/qCXke7t4YEPnZTE4Ro4yz5nrcXGRo9sPuNalgV39oyoTC6OJTPXqJkZ1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/jquery": "^3.5.6",
+        "stimulus": "^2.0.0"
+      }
+    },
+    "node_modules/stimulus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-2.0.0.tgz",
+      "integrity": "sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==",
+      "dev": true,
+      "dependencies": {
+        "@stimulus/core": "^2.0.0",
+        "@stimulus/webpack-helpers": "^2.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@stimulus/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==",
+      "dev": true,
+      "requires": {
+        "@stimulus/mutation-observers": "^2.0.0"
+      }
+    },
+    "@stimulus/multimap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-2.0.0.tgz",
+      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==",
+      "dev": true
+    },
+    "@stimulus/mutation-observers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz",
+      "integrity": "sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==",
+      "dev": true,
+      "requires": {
+        "@stimulus/multimap": "^2.0.0"
+      }
+    },
+    "@stimulus/webpack-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz",
+      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==",
+      "dev": true
+    },
+    "@types/greasemonkey": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
+      "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.8.tgz",
+      "integrity": "sha512-cXk6NwqjDYg+UI9p2l3x0YmPa4m7RrXqmbK4IpVVpRJiYXU/QTo+UZrn54qfE1+9Gao4qpYqUnxm5ZCy2FTXAw==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "@types/tampermonkey": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
+      "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
+      "dev": true
+    },
+    "@userscripters/stackexchange-global-types": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@userscripters/stackexchange-global-types/-/stackexchange-global-types-2.2.1.tgz",
+      "integrity": "sha512-+WTeOcVbIfHFvx+GA3nxYnlhe7MY/qCXke7t4YEPnZTE4Ro4yz5nrcXGRo9sPuNalgV39oyoTC6OJTPXqJkZ1A==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "^3.5.6",
+        "stimulus": "^2.0.0"
+      }
+    },
+    "stimulus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-2.0.0.tgz",
+      "integrity": "sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==",
+      "dev": true,
+      "requires": {
+        "@stimulus/core": "^2.0.0",
+        "@stimulus/webpack-helpers": "^2.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "@types/greasemonkey": "^4.0.2",
+    "@types/tampermonkey": "^4.0.5",
+    "@userscripters/stackexchange-global-types": "^2.2.1"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "checkJs": true,
+        "strict": true,
+        "noEmit": true,
+        "lib": ["DOM", "DOM.Iterable", "ESNext"],
+        "types": [
+            "tampermonkey",
+            "greasemonkey",
+            "@userscripters/stackexchange-global-types"
+        ]
+    },
+    "include": ["."]
+}


### PR DESCRIPTION
This is a small PR focusing on preparing the repo for TS checking (without forcing anyone to actually write in TS) + reworks the `getChatFkey` helper function to use `async`/`await` instead of the redundant here `Promise` constructor (`GM_XML_HTTP_REQUEST` returns an instance of `Promise` in both Tampermonkey and Greasemonkey APIs). Also fixed a typo in `GM_xmlHttpRequest` (should be `GM_xmlHttpRequest`) - according to type definitions, we incorrectly capitalized it (I think we already addressed it, so that might just be a regression).

I tried to preserve as many stylistic choices as possible and only opted to remove the `else` branches to avoid unnecessary indentation. The reasoning is since we always `return` in the `if` branch, there is no need for `else` branch to exist, the code might as well live in the function scope - it will only be reached if the `if` branch is not taken. Feel free to ignore that change, though, it is just my preference.

There will likely be some additions as I read through the userscript